### PR TITLE
Gottagofast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,31 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "approx"
@@ -30,16 +51,116 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -67,12 +188,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+
+[[package]]
 name = "earcutr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
 dependencies = [
- "itertools",
+ "itertools 0.11.0",
  "num-traits",
 ]
 
@@ -119,6 +246,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo-traits"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b018fc19fa58202b03f1c809aebe654f7d70fd3887dace34c3d05c11aeb474b5"
+dependencies = [
+ "geo-types",
+]
+
+[[package]]
 name = "geo-types"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +284,16 @@ checksum = "0fb94b1a65401d6cbf22958a9040aa364812c26674f841bee538b12c135db1e6"
 dependencies = [
  "geo-types",
  "libm",
+]
+
+[[package]]
+name = "half"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+dependencies = [
+ "cfg-if",
+ "crunchy",
 ]
 
 [[package]]
@@ -185,6 +331,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "i_float"
@@ -237,12 +389,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -274,6 +462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +493,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +519,34 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -455,6 +683,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "robust"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,15 +729,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
 name = "rusty-polygon-geohasher"
 version = "0.2.3"
 dependencies = [
+ "criterion",
  "geo",
  "geo-types",
  "geohash",
  "py_geo_interface",
  "pyo3",
  "queue",
+ "wkt",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -507,6 +787,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -551,6 +843,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +883,102 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-targets"
@@ -625,3 +1043,16 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wkt"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c591649bd1c9d4e28459758bbb5fb5c0edc7a67060b52422f4761c94ffe961"
+dependencies = [
+ "geo-traits",
+ "geo-types",
+ "log",
+ "num-traits",
+ "thiserror",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "rusty-polygon-geohasher"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "geo",
  "geo-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ geo-types = "^0.7.13"
 
 [lib]
 name = "geohash_polygon"
+# The crate-type includes both "cdylib" and "rlib" to support multiple use cases:
+# - "cdylib" is required for creating a dynamic library for Python bindings using pyo3.
+# - "rlib" allows the crate to be used as a Rust library in other Rust projects.
 crate-type = ["cdylib", "rlib"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,19 @@ geo-types = "^0.7.13"
 
 [lib]
 name = "geohash_polygon"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [features]
 extension-module = ["pyo3/extension-module"]
 default = ["extension-module"]
+
+[dev-dependencies]
+criterion = "0.5.1"
+wkt = "0.12.0"
+
+[[bench]]
+name = "bench"
+harness = false
 
 #[dependencies.pyo3]
 #version = "0.21.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.3"
 edition = "2021"
 authors = ["Francois Maillet <francois@locallogic.co>"]
 homepage = "https://github.com/nexmoov/rusty-polygon-geohasher"
-lisence = "MIT"
+license = "MIT"
 readme = "README.md"
 keywords=["polygon", "geohashes", "geospatial"]
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,27 +9,27 @@ fn bench_polygons_to_geohashes(c: &mut Criterion) {
 
     let wh = include_str!("../tests/data/whitehorse_wkt.txt");
     let wh: MultiPolygon<f64> = MultiPolygon::try_from_wkt_str(wh).unwrap();
-    c.bench_function("verdun 7 false", |b| {
-        b.iter(|| polygons_to_geohashes(verdun.clone(), 7, false))
-    });
-    c.bench_function("verdun 7 true", |b| {
-        b.iter(|| polygons_to_geohashes(verdun.clone(), 7, true))
-    });
     c.bench_function("verdun 7 false oldfunc", |b| {
         b.iter(|| polygons_to_geohashes_handbrake(verdun.clone(), 7, false))
     });
+    c.bench_function("verdun 7 false", |b| {
+        b.iter(|| polygons_to_geohashes(verdun.clone(), 7, false))
+    });
     c.bench_function("verdun 7 true oldfunc", |b| {
         b.iter(|| polygons_to_geohashes_handbrake(verdun.clone(), 7, true))
+    });
+    c.bench_function("verdun 7 true", |b| {
+        b.iter(|| polygons_to_geohashes(verdun.clone(), 7, true))
     });
 
     c.bench_function("whitehorse 6 false oldfunc", |b| {
         b.iter(|| polygons_to_geohashes_handbrake(wh.clone(), 6, false))
     });
-    c.bench_function("whitehorse 6 true oldfunc", |b| {
-        b.iter(|| polygons_to_geohashes_handbrake(wh.clone(), 6, true))
-    });
     c.bench_function("whitehorse 6 false", |b| {
         b.iter(|| polygons_to_geohashes(wh.clone(), 6, false))
+    });
+    c.bench_function("whitehorse 6 true oldfunc", |b| {
+        b.iter(|| polygons_to_geohashes_handbrake(wh.clone(), 6, true))
     });
     c.bench_function("whitehorse 6 true", |b| {
         b.iter(|| polygons_to_geohashes(wh.clone(), 6, true))

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,40 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use geo::MultiPolygon;
+use geohash_polygon::{polygons_to_geohashes, polygons_to_geohashes_handbrake};
+use wkt::TryFromWkt;
+
+fn bench_polygons_to_geohashes(c: &mut Criterion) {
+    let verdun = include_str!("../tests/data/verdun_wkt.txt");
+    let verdun: MultiPolygon<f64> = MultiPolygon::try_from_wkt_str(verdun).unwrap();
+
+    let wh = include_str!("../tests/data/whitehorse_wkt.txt");
+    let wh: MultiPolygon<f64> = MultiPolygon::try_from_wkt_str(wh).unwrap();
+    c.bench_function("verdun 7 false", |b| {
+        b.iter(|| polygons_to_geohashes(verdun.clone(), 7, false))
+    });
+    c.bench_function("verdun 7 true", |b| {
+        b.iter(|| polygons_to_geohashes(verdun.clone(), 7, true))
+    });
+    c.bench_function("verdun 7 false oldfunc", |b| {
+        b.iter(|| polygons_to_geohashes_handbrake(verdun.clone(), 7, false))
+    });
+    c.bench_function("verdun 7 true oldfunc", |b| {
+        b.iter(|| polygons_to_geohashes_handbrake(verdun.clone(), 7, true))
+    });
+
+    c.bench_function("whitehorse 6 false oldfunc", |b| {
+        b.iter(|| polygons_to_geohashes_handbrake(wh.clone(), 6, false))
+    });
+    c.bench_function("whitehorse 6 true oldfunc", |b| {
+        b.iter(|| polygons_to_geohashes_handbrake(wh.clone(), 6, true))
+    });
+    c.bench_function("whitehorse 6 false", |b| {
+        b.iter(|| polygons_to_geohashes(wh.clone(), 6, false))
+    });
+    c.bench_function("whitehorse 6 true", |b| {
+        b.iter(|| polygons_to_geohashes(wh.clone(), 6, true))
+    });
+}
+
+criterion_group!(benches, bench_polygons_to_geohashes);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ where
 
             if fully_contained_only {
                 // try hard to avoid calling .contains
-                if polygon.unsigned_area() < current_geohash_polygon.unsigned_area()
+                if current_geohash_polygon.unsigned_area() > polygon.unsigned_area()
                     || polygon_exterior.intersects(current_geohash_polygon.exterior())
                     || polygon
                         .interiors()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,75 @@ use geo::{
     BoundingRect, Intersects, Polygon,
 };
 use geo_types::Geometry as GtGeometry;
-use geohash::{decode_bbox, encode, neighbors};
+use geohash::{decode_bbox, encode, neighbors, GeohashError};
 use py_geo_interface::Geometry;
-use pyo3::prelude::*;
 use pyo3::types::PyAny;
 use pyo3::wrap_pyfunction;
+use pyo3::{exceptions::PyValueError, prelude::*};
 use std::collections::{HashSet, VecDeque};
+
+fn polygons_to_geohashes(
+    polygons: Vec<Polygon>,
+    precision: usize,
+    inner: bool,
+) -> Result<HashSet<String>, GeohashError> {
+    let mut inner_geohashes = HashSet::new();
+    let mut outer_geohashes = HashSet::new();
+
+    for polygon in &polygons {
+        let envelope = polygon.bounding_rect().unwrap();
+
+        let centroid = polygon.centroid().unwrap();
+        let centroid_geohash = encode((centroid.x(), centroid.y()).into(), precision)?;
+
+        let mut testing_geohashes = VecDeque::new();
+        testing_geohashes.push_back(centroid_geohash);
+
+        while let Some(current_geohash) = testing_geohashes.pop_front() {
+            if inner_geohashes.contains(&current_geohash)
+                || outer_geohashes.contains(&current_geohash)
+            {
+                continue;
+            }
+
+            let rect_bbox = decode_bbox(&current_geohash)?;
+            let current_geohash_polygon = rect_bbox.to_polygon();
+
+            let condition = if inner {
+                envelope.contains(&rect_bbox)
+            } else {
+                envelope.intersects(&rect_bbox)
+            };
+            if !condition {
+                continue;
+            }
+
+            if inner {
+                if polygon.contains(&current_geohash_polygon) {
+                    inner_geohashes.insert(current_geohash.clone());
+                } else {
+                    outer_geohashes.insert(current_geohash.clone());
+                }
+            } else {
+                if polygon.intersects(&current_geohash_polygon) {
+                    inner_geohashes.insert(current_geohash.clone());
+                } else {
+                    outer_geohashes.insert(current_geohash.clone());
+                }
+            }
+
+            if let Ok(rez) = neighbors(&current_geohash) {
+                for neighbor in [rez.sw, rez.s, rez.se, rez.w, rez.e, rez.nw, rez.n, rez.ne] {
+                    if !inner_geohashes.contains(&neighbor) && !outer_geohashes.contains(&neighbor)
+                    {
+                        testing_geohashes.push_back(neighbor.to_string());
+                    }
+                }
+            }
+        }
+    }
+    Ok(inner_geohashes)
+}
 
 #[pyfunction]
 fn polygon_to_geohashes(
@@ -17,9 +80,6 @@ fn polygon_to_geohashes(
     precision: usize,
     inner: bool,
 ) -> PyResult<HashSet<String>> {
-    let mut inner_geohashes = HashSet::new();
-    let mut outer_geohashes = HashSet::new();
-
     let mut polygons = Vec::<Polygon<f64>>::new();
 
     let geom: Geometry = match py_polygon.extract::<Geometry>() {
@@ -49,60 +109,8 @@ fn polygon_to_geohashes(
         return Err(pyo3::exceptions::PyValueError::new_err(e));
     }
 
-    for polygon in &polygons {
-        let envelope = polygon.bounding_rect().unwrap();
-        let poly_envelope = envelope.to_polygon();
-
-        let centroid = polygon.centroid().unwrap();
-        let centroid_geohash = encode((centroid.x(), centroid.y()).into(), precision)
-            .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{:?}", e)))?;
-
-        let mut testing_geohashes = VecDeque::new();
-        testing_geohashes.push_back(centroid_geohash);
-
-        while let Some(current_geohash) = testing_geohashes.pop_front() {
-            if !inner_geohashes.contains(&current_geohash)
-                && !outer_geohashes.contains(&current_geohash)
-            {
-                let rect_bbox = decode_bbox(&current_geohash)
-                    .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{:?}", e)))?;
-                let current_polygon = rect_bbox.to_polygon();
-
-                let condition = if inner {
-                    poly_envelope.contains(&current_polygon)
-                } else {
-                    poly_envelope.intersects(&current_polygon)
-                };
-                if condition {
-                    if inner {
-                        if polygon.contains(&current_polygon) {
-                            inner_geohashes.insert(current_geohash.clone());
-                        } else {
-                            outer_geohashes.insert(current_geohash.clone());
-                        }
-                    } else {
-                        if polygon.intersects(&current_polygon) {
-                            inner_geohashes.insert(current_geohash.clone());
-                        } else {
-                            outer_geohashes.insert(current_geohash.clone());
-                        }
-                    }
-
-                    if let Ok(rez) = neighbors(&current_geohash) {
-                        for neighbor in [rez.sw, rez.s, rez.se, rez.w, rez.e, rez.nw, rez.n, rez.ne]
-                        {
-                            if !inner_geohashes.contains(&neighbor)
-                                && !outer_geohashes.contains(&neighbor)
-                            {
-                                testing_geohashes.push_back(neighbor.to_string());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    Ok(inner_geohashes)
+    polygons_to_geohashes(polygons, precision, inner)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{:?}", e)))
 }
 
 #[pymodule]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,13 +13,13 @@ use std::collections::{HashSet, VecDeque};
 fn polygons_to_geohashes(
     polygons: Vec<Polygon>,
     precision: usize,
-    inner: bool,
+    fully_contained_only: bool,
 ) -> Result<HashSet<String>, GeohashError> {
-    let mut inner_geohashes = HashSet::new();
-    let mut outer_geohashes = HashSet::new();
+    let mut accepted_geohashes = HashSet::new();
+    let mut rejected_geohashes = HashSet::new();
 
     for polygon in &polygons {
-        let envelope = polygon.bounding_rect().unwrap();
+        let polygon_exterior = polygon.exterior();
 
         let centroid = polygon.centroid().unwrap();
         let centroid_geohash = encode((centroid.x(), centroid.y()).into(), precision)?;
@@ -28,41 +28,35 @@ fn polygons_to_geohashes(
         testing_geohashes.push_back(centroid_geohash);
 
         while let Some(current_geohash) = testing_geohashes.pop_front() {
-            if inner_geohashes.contains(&current_geohash)
-                || outer_geohashes.contains(&current_geohash)
+            if accepted_geohashes.contains(&current_geohash)
+                || rejected_geohashes.contains(&current_geohash)
             {
                 continue;
             }
 
-            let rect_bbox = decode_bbox(&current_geohash)?;
-            let current_geohash_polygon = rect_bbox.to_polygon();
+            let gh_bbox = decode_bbox(&current_geohash)?;
+            let current_geohash_polygon = gh_bbox.to_polygon();
 
-            let condition = if inner {
-                envelope.contains(&rect_bbox)
-            } else {
-                envelope.intersects(&rect_bbox)
-            };
-            if !condition {
+            if !polygon.intersects(&current_geohash_polygon) {
+                // not intersecting or inside, reject
+                rejected_geohashes.insert(current_geohash.clone());
                 continue;
             }
 
-            if inner {
-                if polygon.contains(&current_geohash_polygon) {
-                    inner_geohashes.insert(current_geohash.clone());
+            if fully_contained_only {
+                if polygon_exterior.intersects(current_geohash_polygon.exterior()) {
+                    rejected_geohashes.insert(current_geohash.clone());
                 } else {
-                    outer_geohashes.insert(current_geohash.clone());
+                    accepted_geohashes.insert(current_geohash.clone());
                 }
             } else {
-                if polygon.intersects(&current_geohash_polygon) {
-                    inner_geohashes.insert(current_geohash.clone());
-                } else {
-                    outer_geohashes.insert(current_geohash.clone());
-                }
+                // it intersects, keep it
+                accepted_geohashes.insert(current_geohash.clone());
             }
-
             if let Ok(rez) = neighbors(&current_geohash) {
                 for neighbor in [rez.sw, rez.s, rez.se, rez.w, rez.e, rez.nw, rez.n, rez.ne] {
-                    if !inner_geohashes.contains(&neighbor) && !outer_geohashes.contains(&neighbor)
+                    if !accepted_geohashes.contains(&neighbor)
+                        && !rejected_geohashes.contains(&neighbor)
                     {
                         testing_geohashes.push_back(neighbor.to_string());
                     }
@@ -70,7 +64,7 @@ fn polygons_to_geohashes(
             }
         }
     }
-    Ok(inner_geohashes)
+    Ok(accepted_geohashes)
 }
 
 #[pyfunction]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,12 @@ fn polygons_to_geohashes(
             }
 
             if fully_contained_only {
-                if polygon_exterior.intersects(current_geohash_polygon.exterior()) {
+                if polygon_exterior.intersects(current_geohash_polygon.exterior())
+                    || polygon
+                        .interiors()
+                        .iter()
+                        .any(|hole| hole.intersects(current_geohash_polygon.exterior()))
+                {
                     rejected_geohashes.insert(current_geohash.clone());
                 } else {
                     accepted_geohashes.insert(current_geohash.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-use geo::{algorithm::centroid::Centroid, Intersects, Polygon};
+use geo::{algorithm::centroid::Centroid, Area, BoundingRect, Contains, Intersects, Polygon};
+
 use geo_types::Geometry as GtGeometry;
 use geohash::{decode_bbox, encode, neighbors, GeohashError};
 use py_geo_interface::Geometry;
@@ -72,6 +73,72 @@ where
         }
     }
     Ok(accepted_geohashes)
+}
+
+pub fn polygons_to_geohashes_handbrake<PI>(
+    polygons: PI,
+    precision: usize,
+    inner: bool,
+) -> Result<HashSet<String>, GeohashError>
+where
+    PI: IntoIterator<Item = Polygon>,
+{
+    let mut inner_geohashes = HashSet::new();
+    let mut outer_geohashes = HashSet::new();
+
+    for polygon in polygons {
+        let envelope = polygon.bounding_rect().unwrap();
+
+        let centroid = polygon.centroid().unwrap();
+        let centroid_geohash = encode((centroid.x(), centroid.y()).into(), precision)?;
+
+        let mut testing_geohashes = VecDeque::new();
+        testing_geohashes.push_back(centroid_geohash);
+
+        while let Some(current_geohash) = testing_geohashes.pop_front() {
+            if inner_geohashes.contains(&current_geohash)
+                || outer_geohashes.contains(&current_geohash)
+            {
+                continue;
+            }
+
+            let rect_bbox = decode_bbox(&current_geohash)?;
+            let current_geohash_polygon = rect_bbox.to_polygon();
+
+            let condition = if inner {
+                envelope.contains(&rect_bbox)
+            } else {
+                envelope.intersects(&rect_bbox)
+            };
+            if !condition {
+                continue;
+            }
+
+            if inner {
+                if polygon.contains(&current_geohash_polygon) {
+                    inner_geohashes.insert(current_geohash.clone());
+                } else {
+                    outer_geohashes.insert(current_geohash.clone());
+                }
+            } else {
+                if polygon.intersects(&current_geohash_polygon) {
+                    inner_geohashes.insert(current_geohash.clone());
+                } else {
+                    outer_geohashes.insert(current_geohash.clone());
+                }
+            }
+
+            if let Ok(rez) = neighbors(&current_geohash) {
+                for neighbor in [rez.sw, rez.s, rez.se, rez.w, rez.e, rez.nw, rez.n, rez.ne] {
+                    if !inner_geohashes.contains(&neighbor) && !outer_geohashes.contains(&neighbor)
+                    {
+                        testing_geohashes.push_back(neighbor.to_string());
+                    }
+                }
+            }
+        }
+    }
+    Ok(inner_geohashes)
 }
 
 #[pyfunction]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,10 @@
-use geo::{
-    algorithm::{centroid::Centroid, contains::Contains},
-    BoundingRect, Intersects, Polygon,
-};
+use geo::{algorithm::centroid::Centroid, Intersects, Polygon};
 use geo_types::Geometry as GtGeometry;
 use geohash::{decode_bbox, encode, neighbors, GeohashError};
 use py_geo_interface::Geometry;
+use pyo3::prelude::*;
 use pyo3::types::PyAny;
 use pyo3::wrap_pyfunction;
-use pyo3::{exceptions::PyValueError, prelude::*};
 use std::collections::{HashSet, VecDeque};
 
 fn polygons_to_geohashes(


### PR DESCRIPTION
This PR has multiple things in it:
- extract polygon logic in a function to be able to call it from rust without pirouettes
- allow the func to work with any iterator that yields `Polygons` (not just `Vec<Polygon>`)
- rename variables to "better" express intent. (for my definition of "better" :trollface: )
- add simple benchmark to compare old and new function

And finally, tweak algorithm to avoid calls to `polygon.contains` since it is quite expensive.
Instead:
- Prefilter geohash using `polygon.intersects(geohash_polygon)`.
  this check is relatively cheap and it is a superset of `contains` when operating on polygons.
- if `fully_contained_only` is false and they intersect, we're done.
- Otherwise, check that the geohash is fully contained by making sure that:
  - geohash's area is smaller or equal to the polygon's area
  - geohash perimeter doesn't intersect with any of the polygon's edges (internal or external)

on an i7 7700 on linux amd64, it shows the following improvement:
```
verdun 7 false oldfunc: 26ms
verdun 7 false: 9ms
verdun 7 true oldfunc: 163.95
verdun 7 true: 11ms

whitehorse 6 false oldfunc:  648ms
whitehorse 6 false: 175ms
whitehorse 6 true oldfunc:  4000ms
whitehorse 6 true: 260ms
```
 3.7x for whitehorse inner=false
15x for whitehorse inner=true

