### PR TITLE
fix: reset rejected_geohashes per polygon in multipolygon BFS (#18)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-polygon-geohasher"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Francois Maillet <francois@locallogic.co>"]
 homepage = "https://github.com/nexmoov/rusty-polygon-geohasher"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rusty-polygon-geohasher"
-version = "0.4.0"
+version = "0.4.1"
 description = "A Rust implementation of the polygon to geohash library"
 readme = "README.md"
 authors = ["Francois Maillet <francois@locallogic.co>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,11 @@ where
     PI: IntoIterator<Item = Polygon>,
 {
     let mut accepted_geohashes = HashSet::new();
-    let mut rejected_geohashes = HashSet::new();
 
     for polygon in polygons {
+        // Reset per polygon: a cell rejected by one polygon in a multipolygon
+        // must still be tested against the others.
+        let mut rejected_geohashes = HashSet::new();
         let polygon_exterior = polygon.exterior();
         let has_holes = !polygon.interiors().is_empty();
 

--- a/tests/test_geohasher.py
+++ b/tests/test_geohasher.py
@@ -39,6 +39,23 @@ def test_exception_when_malformed_geo_interface(polygon, expected_message):
         geohash_polygon.polygon_to_geohashes(polygon, 3, True)
 
 
+def test_multipolygon_regression_issue_18():
+    """Regression test for issue #18.
+
+    rejected_geohashes was shared across polygons in a multipolygon, so cells
+    rejected by the first polygon's BFS were permanently blacklisted and never
+    tested against subsequent polygons — causing geohashes like 'u6' to be
+    silently dropped from the result.
+    """
+    mp = shapely.from_wkt(
+        "MULTIPOLYGON ("
+        "((12.850269 52.752106, 11.850269 51.754758, 10.862241 49.754758, 13.862241 53.52106, 12.850269 52.752106)),"
+        "((14.850269 56.752106, 13.850269 55.754758, 12.862241 54.754758, 15.862241 57.52106, 14.850269 56.752106))"
+        ")"
+    )
+    assert geohash_polygon.polygon_to_geohashes(mp, 2, False) == {"u0", "u2", "u3", "u6"}
+
+
 @pytest.mark.parametrize(
     "polygon, exception_message_idx",
     [


### PR DESCRIPTION
Fixes #18

  ## Root cause

  `rejected_geohashes` was declared outside the `for polygon in polygons`
  loop and shared across all sub-polygons. A cell rejected by the first
  polygon's BFS (because it didn't intersect that polygon) was
  permanently blacklisted — so when subsequent polygons' BFS tried to
  visit it, the early `continue` fired and it was never tested against
  them.

  ## Fix

  Move `rejected_geohashes` inside the loop so it resets per polygon.
  `accepted_geohashes` stays shared — a cell accepted by any polygon
  correctly belongs in the result.

  ## Test

  Adds a regression test using the exact multipolygon and expected
  result from the issue report (`{"u0", "u2", "u3", "u6"}` at
  precision 2, intersecting mode).