### PR TITLE
add encode, decode, expand_geohash_mapping functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
@@ -222,6 +222,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "geo"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
 dependencies = [
  "approx",
  "num-traits",
@@ -435,19 +459,21 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -497,6 +523,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -630,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -660,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -732,7 +764,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-polygon-geohasher"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "geo",
@@ -740,6 +772,7 @@ dependencies = [
  "geohash",
  "pyo3",
  "queue",
+ "rayon",
  "wkt",
 ]
 
@@ -800,6 +833,12 @@ name = "sif-itree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -902,9 +941,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -915,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -925,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -938,18 +977,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-polygon-geohasher"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 authors = ["Francois Maillet <francois@locallogic.co>"]
 homepage = "https://github.com/nexmoov/rusty-polygon-geohasher"
@@ -14,6 +14,7 @@ geo = "^0.32"
 geohash = "^0.13.1"
 queue = "^0.3.1"
 geo-types = "^0.7.13"
+rayon = "^1"
 
 [lib]
 name = "geohash_polygon"
@@ -28,6 +29,7 @@ default = ["extension-module"]
 
 [dev-dependencies]
 criterion = "0.5.1"
+geohash = "^0.13.1"
 wkt = "0.12.0"
 
 [[bench]]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 .PHONY: test
 test:
-	poetry run maturin develop -r && poetry run pytest tests/test_geohasher.py
+	poetry run maturin develop -r && poetry run pytest tests
 
 
 .PHONY: format

--- a/README.md
+++ b/README.md
@@ -4,26 +4,72 @@
 
 # rusty-polygon-geohasher
 
-Polygon Geohasher is an open source Python package for converting Shapely's polygons into a set of geohashes. It obtains the set of geohashes inside a polygon or geohashes that touch (intersect) the polygon.
+A Rust-backed Python library for geohash operations: converting Shapely polygons to geohash sets,
+encode/decode, and geography expansion. All compute-heavy paths use Rayon for parallelism.
 
-The library is based on the [polygon-geohasher](https://github.com/Bonsanto/polygon-geohasher) library which is implemented in pure python. The main difference is that this library is implemented in Rust, yielding a significant performance improvement.
+Originally based on [polygon-geohasher](https://github.com/Bonsanto/polygon-geohasher) (pure Python).
+
+The encode/decode functions are a maintained replacement for
+[pygeohash-fast](https://github.com/PadenZach/pygeohash-fast), which is no longer actively maintained.
 
 
 ## Installing
-You can get the library from the Python Package Index (PyPI) using pip:
 
-`$ pip install rusty-polygon-geohasher`
+```
+pip install rusty-polygon-geohasher
+```
 
 
 ## Usage
-Here are some simple examples:
+
+### Polygon → geohash set
 
 ```python
-from polygon_geohasher.polygon_geohasher import polygon_to_geohashes
+import geohash_polygon
 from shapely import geometry
 
 polygon = geometry.Polygon([(-99.1795917, 19.432134), (-99.1656847, 19.429034),
                             (-99.1776492, 19.414236), (-99.1795917, 19.432134)])
-inner_geohashes_polygon = geohash_polygon.polygon_to_geohashes(polygon, 7, inner=True)
-outer_geohashes_polygon = geohash_polygon.polygon_to_geohashes(polygon, 7, inner=False)
+
+inner = geohash_polygon.polygon_to_geohashes(polygon, precision=7, inner=True)
+outer = geohash_polygon.polygon_to_geohashes(polygon, precision=7, inner=False)
 ```
+
+### Encode / decode
+
+All functions use `(lng, lat)` order consistently — encode takes `(lng, lat)` and all decode
+functions return `(lng, lat, ...)`.
+
+```python
+# Single encode/decode
+h = geohash_polygon.encode(lng=-73.554, lat=45.508, precision=7)
+lng, lat, lng_err, lat_err = geohash_polygon.decode_exactly(h)
+
+# Batch (parallel via Rayon)
+hashes = geohash_polygon.encode_many(lngs=[...], lats=[...], precision=7)
+centers = geohash_polygon.decode_many(hashes)           # list of (lng, lat)
+exact   = geohash_polygon.decode_many_exactly(hashes)   # list of (lng, lat, lng_err, lat_err)
+
+# Optional thread count
+geohash_polygon.encode_many(lngs, lats, 7, num_threads=4)
+geohash_polygon.decode_many(hashes, num_threads=4)
+geohash_polygon.decode_many_exactly(hashes, num_threads=4)
+```
+
+### Expand geohash mappings
+
+Expand each geography's geohash set outward by a given distance in metres. Useful when you
+want to count or join points-of-interest slightly outside a geography's boundary.
+
+```python
+# Single group
+expanded = geohash_polygon.expand_geohashes(["f25dvz3", "f25dvz4", ...], expansion_m=500.0)
+
+# Multiple groups — result[i] is the expanded version of groups[i]
+groups = [["f25dvz3", "f25dvz4", ...], [...]]
+expanded_groups = geohash_polygon.expand_geohash_mapping(groups, expansion_m=500.0)
+```
+
+The hop count is derived from the minimum cell dimension (accounting for latitude-dependent cell
+width), so expansion is accurate in all directions including east/west at high latitudes. All
+hashes in a group must have the same precision. Geography expansion runs in parallel across groups.

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,6 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use geo::MultiPolygon;
-use geohash_polygon::{polygons_to_geohashes, polygons_to_geohashes_handbrake};
+use geohash::decode_bbox;
+use geohash_polygon::{expand_geohash_set, polygons_to_geohashes, polygons_to_geohashes_handbrake};
+use std::collections::HashSet;
 use wkt::TryFromWkt;
 
 fn bench_polygons_to_geohashes(c: &mut Criterion) {
@@ -36,5 +38,26 @@ fn bench_polygons_to_geohashes(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_polygons_to_geohashes);
+fn bench_expand_geohash_set(c: &mut Criterion) {
+    let wh = include_str!("../tests/data/whitehorse_wkt.txt");
+    let wh: MultiPolygon<f64> = MultiPolygon::try_from_wkt_str(wh).unwrap();
+
+    // Large high-latitude geography: good stress test for both hop count and
+    // lat-dependent cell-width distortion.
+    let geohashes: HashSet<String> = polygons_to_geohashes(wh, 6, false).unwrap();
+    println!("Whitehorse p6 cell count: {}", geohashes.len());
+
+    let sample_bbox = decode_bbox(geohashes.iter().next().unwrap()).unwrap();
+    let cell_height_m = (sample_bbox.max().y - sample_bbox.min().y) * 111_000.0;
+
+    for expansion_m in [500.0_f64, 2000.0_f64] {
+        let n_hops = (expansion_m / cell_height_m).ceil() as usize;
+        c.bench_function(
+            &format!("expand_geohash_set whitehorse p6 {expansion_m}m ({n_hops} hops)"),
+            |b| b.iter(|| expand_geohash_set(&geohashes, n_hops).unwrap()),
+        );
+    }
+}
+
+criterion_group!(benches, bench_polygons_to_geohashes, bench_expand_geohash_set);
 criterion_main!(benches);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rusty-polygon-geohasher"
-version = "0.4.1"
+version = "0.5.0"
 description = "A Rust implementation of the polygon to geohash library"
 readme = "README.md"
 authors = ["Francois Maillet <francois@locallogic.co>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,78 @@ use geohash::{decode_bbox, encode, neighbors, GeohashError};
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
 use pyo3::wrap_pyfunction;
+use rayon::prelude::*;
 use std::collections::{HashSet, VecDeque};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Build a custom thread pool, or return `None` to use the global Rayon pool.
+///
+/// Call this *before* releasing the GIL so that pool-creation errors can be
+/// converted to Python exceptions while we still hold it.
+fn make_pool(num_threads: Option<usize>) -> PyResult<Option<rayon::ThreadPool>> {
+    match num_threads {
+        None => Ok(None),
+        Some(n) => rayon::ThreadPoolBuilder::new()
+            .num_threads(n)
+            .build()
+            .map(Some)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
+    }
+}
+
+/// Run `f` on `pool`, or on the global Rayon pool if `pool` is `None`.
+///
+/// Call this *inside* `py.allow_threads` so the GIL is released while Rayon
+/// workers are running.
+fn run_with_pool<F, T>(pool: &Option<rayon::ThreadPool>, f: F) -> T
+where
+    F: FnOnce() -> T + Send,
+    T: Send,
+{
+    match pool {
+        None => f(),
+        Some(p) => p.install(f),
+    }
+}
+
+fn all_neighbors(hash: &str) -> Result<[String; 8], GeohashError> {
+    let nbrs = neighbors(hash)?;
+    Ok([nbrs.n, nbrs.ne, nbrs.e, nbrs.se, nbrs.s, nbrs.sw, nbrs.w, nbrs.nw])
+}
+
+/// BFS frontier expansion: expand a set of geohashes outward by `n_hops` steps.
+/// Returns an error if any hash in the input set is malformed.
+pub fn expand_geohash_set(
+    geohashes: &HashSet<String>,
+    n_hops: usize,
+) -> Result<HashSet<String>, GeohashError> {
+    let mut all = geohashes.clone();
+    // Initial frontier: input cells with at least one neighbor outside the set.
+    // Neighbour lookup here validates user-provided hashes.
+    let mut frontier: HashSet<String> = HashSet::new();
+    for gh in all.iter() {
+        let nbrs = all_neighbors(gh)?;
+        if nbrs.iter().any(|n| !all.contains(n)) {
+            frontier.insert(gh.clone());
+        }
+    }
+    for _ in 0..n_hops {
+        let mut new_frontier: HashSet<String> = HashSet::new();
+        for gh in &frontier {
+            for n in all_neighbors(gh)? {
+                if !all.contains(&n) {
+                    new_frontier.insert(n);
+                }
+            }
+        }
+        all.extend(new_frontier.iter().cloned());
+        frontier = new_frontier;
+    }
+    Ok(all)
+}
+
+// ── Polygon → geohash (existing) ─────────────────────────────────────────────
 
 pub fn polygons_to_geohashes<PI>(
     polygons: PI,
@@ -207,19 +278,23 @@ fn polygon_to_geohashes(
 
     let geom_type: String = geo_interface
         .get_item("type")
-        .map_err(|_| pyo3::exceptions::PyValueError::new_err(
-            "__geo_interface__ mapping is missing the required 'type' key",
-        ))?
+        .map_err(|_| {
+            pyo3::exceptions::PyValueError::new_err(
+                "__geo_interface__ mapping is missing the required 'type' key",
+            )
+        })?
         .extract()
-        .map_err(|_| pyo3::exceptions::PyValueError::new_err(
-            "__geo_interface__ 'type' value must be a string",
-        ))?;
+        .map_err(|_| {
+            pyo3::exceptions::PyValueError::new_err(
+                "__geo_interface__ 'type' value must be a string",
+            )
+        })?;
 
-    let coordinates = geo_interface
-        .get_item("coordinates")
-        .map_err(|_| pyo3::exceptions::PyValueError::new_err(
+    let coordinates = geo_interface.get_item("coordinates").map_err(|_| {
+        pyo3::exceptions::PyValueError::new_err(
             "__geo_interface__ mapping is missing the required 'coordinates' key",
-        ))?;
+        )
+    })?;
 
     let polygons = match geom_type.as_str() {
         "Polygon" => vec![extract_polygon(&coordinates)?],
@@ -235,11 +310,219 @@ fn polygon_to_geohashes(
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{e:?}")))
 }
 
+// ── Encode / decode ───────────────────────────────────────────────────────────
+
+/// Encode a single (lng, lat) coordinate to a geohash of the given precision.
+#[pyfunction]
+#[pyo3(name = "encode")]
+fn encode_py(lng: f64, lat: f64, precision: usize) -> PyResult<String> {
+    encode((lng, lat).into(), precision)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+}
+
+/// Encode parallel lists of longitudes and latitudes to geohashes (parallel).
+#[pyfunction]
+#[pyo3(signature = (lngs, lats, precision, num_threads=None))]
+fn encode_many(
+    py: Python<'_>,
+    lngs: Vec<f64>,
+    lats: Vec<f64>,
+    precision: usize,
+    num_threads: Option<usize>,
+) -> PyResult<Vec<String>> {
+    if lngs.len() != lats.len() {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "lngs and lats must have the same length",
+        ));
+    }
+    let pool = make_pool(num_threads)?;
+    let raw: Vec<Result<String, GeohashError>> = py.allow_threads(|| {
+        run_with_pool(&pool, || {
+            lngs.into_par_iter()
+                .zip_eq(lats)
+                .map(|(lng, lat)| encode((lng, lat).into(), precision))
+                .collect()
+        })
+    });
+    raw.into_iter()
+        .map(|r| r.map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string())))
+        .collect()
+}
+
+/// Decode a geohash to (lng, lat, lng_err, lat_err) — lng-first, matching encode convention.
+#[pyfunction]
+fn decode_exactly(hash_str: &str) -> PyResult<(f64, f64, f64, f64)> {
+    let bbox = decode_bbox(hash_str)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    let lat = (bbox.min().y + bbox.max().y) / 2.0;
+    let lng = (bbox.min().x + bbox.max().x) / 2.0;
+    let lat_err = (bbox.max().y - bbox.min().y) / 2.0;
+    let lng_err = (bbox.max().x - bbox.min().x) / 2.0;
+    Ok((lng, lat, lng_err, lat_err))
+}
+
+/// Decode a list of geohashes to (lng, lat) center pairs (parallel).
+#[pyfunction]
+#[pyo3(signature = (geohashes, num_threads=None))]
+fn decode_many(
+    py: Python<'_>,
+    geohashes: Vec<String>,
+    num_threads: Option<usize>,
+) -> PyResult<Vec<(f64, f64)>> {
+    let pool = make_pool(num_threads)?;
+    let raw: Vec<Result<(f64, f64), GeohashError>> = py.allow_threads(|| {
+        run_with_pool(&pool, || {
+            geohashes
+                .into_par_iter()
+                .map(|hash| {
+                    decode_bbox(&hash).map(|bbox| {
+                        let lat = (bbox.min().y + bbox.max().y) / 2.0;
+                        let lng = (bbox.min().x + bbox.max().x) / 2.0;
+                        (lng, lat)
+                    })
+                })
+                .collect()
+        })
+    });
+    raw.into_iter()
+        .map(|r| r.map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string())))
+        .collect()
+}
+
+/// Decode a list of geohashes to (lng, lat, lng_err, lat_err) tuples (parallel).
+#[pyfunction]
+#[pyo3(signature = (geohashes, num_threads=None))]
+fn decode_many_exactly(
+    py: Python<'_>,
+    geohashes: Vec<String>,
+    num_threads: Option<usize>,
+) -> PyResult<Vec<(f64, f64, f64, f64)>> {
+    let pool = make_pool(num_threads)?;
+    let raw: Vec<Result<(f64, f64, f64, f64), GeohashError>> = py.allow_threads(|| {
+        run_with_pool(&pool, || {
+            geohashes
+                .into_par_iter()
+                .map(|hash| {
+                    decode_bbox(&hash).map(|bbox| {
+                        let lat = (bbox.min().y + bbox.max().y) / 2.0;
+                        let lng = (bbox.min().x + bbox.max().x) / 2.0;
+                        let lat_err = (bbox.max().y - bbox.min().y) / 2.0;
+                        let lng_err = (bbox.max().x - bbox.min().x) / 2.0;
+                        (lng, lat, lng_err, lat_err)
+                    })
+                })
+                .collect()
+        })
+    });
+    raw.into_iter()
+        .map(|r| r.map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string())))
+        .collect()
+}
+
+// ── Geography expansion ───────────────────────────────────────────────────────
+
+fn n_hops_for(sample_hash: &str, expansion_m: f64) -> PyResult<usize> {
+    if !expansion_m.is_finite() || expansion_m < 0.0 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "expansion_m must be a finite non-negative number",
+        ));
+    }
+    let bbox = decode_bbox(sample_hash)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("invalid geohash: {e}")))?;
+    let lat_center = (bbox.min().y + bbox.max().y) / 2.0;
+    let cell_height_m = (bbox.max().y - bbox.min().y) * 111_000.0;
+    let cell_width_m = (bbox.max().x - bbox.min().x) * 111_320.0 * lat_center.to_radians().cos();
+    let min_cell_m = cell_height_m.min(cell_width_m);
+    Ok((expansion_m / min_cell_m).ceil() as usize)
+}
+
+/// Expand a single group of geohashes outward by `expansion_m` metres.
+///
+/// The hop count is derived from the cell height of a sample hash, so it works
+/// for any precision level.
+#[pyfunction]
+fn expand_geohashes(py: Python<'_>, geohashes: Vec<String>, expansion_m: f64) -> PyResult<Vec<String>> {
+    if geohashes.is_empty() {
+        return Ok(vec![]);
+    }
+    let expected_len = geohashes.first().unwrap().len();
+    if geohashes.iter().any(|h| h.len() != expected_len) {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "all geohashes must have the same precision",
+        ));
+    }
+    let n_hops = n_hops_for(geohashes.first().unwrap(), expansion_m)?;
+    let hash_set: HashSet<String> = geohashes.into_iter().collect();
+    py.allow_threads(|| expand_geohash_set(&hash_set, n_hops))
+        .map(|s| s.into_iter().collect())
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+}
+
+/// Expand multiple groups of geohashes outward by `expansion_m` metres.
+///
+/// Each input group is expanded independently. Output order matches input order —
+/// `result[i]` is the expanded version of `groups[i]`. Groups are processed in
+/// parallel across geographies via Rayon.
+///
+/// The hop count is derived per group from the cell height of the group's first
+/// hash, so groups at different precision levels are each handled correctly.
+#[pyfunction]
+fn expand_geohash_mapping(
+    py: Python<'_>,
+    groups: Vec<Vec<String>>,
+    expansion_m: f64,
+) -> PyResult<Vec<Vec<String>>> {
+    if groups.is_empty() {
+        return Ok(vec![]);
+    }
+    // Compute n_hops per group sequentially (fast, may raise PyErr) before releasing the GIL.
+    let n_hops_per_group: Vec<usize> = groups
+        .iter()
+        .map(|g| match g.first() {
+            Some(h) => {
+                let expected_len = h.len();
+                if g.iter().any(|gh| gh.len() != expected_len) {
+                    return Err(pyo3::exceptions::PyValueError::new_err(
+                        "all geohashes in a group must have the same precision",
+                    ));
+                }
+                n_hops_for(h, expansion_m)
+            }
+            None => Ok(0),
+        })
+        .collect::<PyResult<_>>()?;
+
+    let raw: Vec<Result<Vec<String>, GeohashError>> = py.allow_threads(|| {
+        groups
+            .into_par_iter()
+            .zip(n_hops_per_group.into_par_iter())
+            .map(|(hashes, n_hops)| {
+                let hash_set: HashSet<String> = hashes.into_iter().collect();
+                expand_geohash_set(&hash_set, n_hops).map(|s| s.into_iter().collect())
+            })
+            .collect()
+    });
+    raw.into_iter()
+        .map(|r| r.map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string())))
+        .collect()
+}
+
+// ── Module ────────────────────────────────────────────────────────────────────
+
 #[pymodule]
 fn geohash_polygon(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(polygon_to_geohashes, m)?)?;
+    m.add_function(wrap_pyfunction!(encode_py, m)?)?;
+    m.add_function(wrap_pyfunction!(encode_many, m)?)?;
+    m.add_function(wrap_pyfunction!(decode_exactly, m)?)?;
+    m.add_function(wrap_pyfunction!(decode_many, m)?)?;
+    m.add_function(wrap_pyfunction!(decode_many_exactly, m)?)?;
+    m.add_function(wrap_pyfunction!(expand_geohashes, m)?)?;
+    m.add_function(wrap_pyfunction!(expand_geohash_mapping, m)?)?;
     Ok(())
 }
+
+// ── Interior seed (existing) ──────────────────────────────────────────────────
 
 /// Ultra-fast interior seed with no RNG, no runtime trig.
 /// Fixed set of offsets → tight upper bound on `contains` calls.

--- a/tests/test_geohash_ops.py
+++ b/tests/test_geohash_ops.py
@@ -1,0 +1,312 @@
+"""Tests for encode, decode_exactly, decode_many, encode_many, expand_geohash_mapping."""
+
+import math
+import pytest
+import geohash_polygon
+
+
+def haversine_m(lng1, lat1, lng2, lat2):
+    R = 6_371_000
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    a = (math.sin(math.radians(lat2 - lat1) / 2) ** 2
+         + math.cos(phi1) * math.cos(phi2) * math.sin(math.radians(lng2 - lng1) / 2) ** 2)
+    return 2 * R * math.asin(math.sqrt(a))
+
+# ── ported from pygeohash-fast ────────────
+def test_encode_works():
+    assert geohash_polygon.encode(-72.747917, 45.207615, 5) == "f2h30"
+
+def test_decode_many_works():
+    assert geohash_polygon.decode_many(["f2h30", "f2h30"]) == [(-72.75146484375, 45.19775390625), (-72.75146484375, 45.19775390625)]
+
+def test_encode_many_works():
+    lats = [47.1, 35.204]
+    lngs = [-76.6, -80.8501]
+    expected = ["f23e", "dnq8"]
+    assert geohash_polygon.encode_many(lngs, lats, 4) == expected
+
+# ── encode / decode_exactly round-trip ───────────────────────────────────────
+
+def test_encode_returns_correct_length():
+    for precision in range(1, 9):
+        result = geohash_polygon.encode(-73.5540, 45.5088, precision)
+        assert isinstance(result, str)
+        assert len(result) == precision
+
+
+def test_encode_decode_exactly_roundtrip():
+    lat, lng, precision = 45.5088, -73.5540, 7
+    encoded = geohash_polygon.encode(lng, lat, precision)
+    decoded_lng, decoded_lat, lng_err, lat_err = geohash_polygon.decode_exactly(encoded)
+    assert abs(decoded_lat - lat) <= lat_err
+    assert abs(decoded_lng - lng) <= lng_err
+
+
+def test_decode_exactly_error_bounds_nonzero():
+    encoded = geohash_polygon.encode(-73.5540, 45.5088, 7)
+    _, _, lat_err, lng_err = geohash_polygon.decode_exactly(encoded)
+    assert lat_err > 0
+    assert lng_err > 0
+
+
+def test_decode_exactly_invalid_raises():
+    with pytest.raises(ValueError):
+        geohash_polygon.decode_exactly("not_a_geohash!")
+
+
+# ── encode_many ───────────────────────────────────────────────────────────────
+
+def test_encode_many_matches_encode():
+    coords = [
+        (-73.5540, 45.5088),
+        (-79.3832, 43.6532),
+        (-87.6298, 41.8781),
+    ]
+    lngs = [c[0] for c in coords]
+    lats = [c[1] for c in coords]
+    results = geohash_polygon.encode_many(lngs, lats, 7)
+    for (lng, lat), result in zip(coords, results):
+        assert result == geohash_polygon.encode(lng, lat, 7)
+
+
+def test_encode_many_mismatched_lengths_raises():
+    with pytest.raises(ValueError, match="same length"):
+        geohash_polygon.encode_many([-73.0, -74.0], [45.0], 7)
+
+
+def test_encode_many_invalid_precision_raises():
+    with pytest.raises(Exception):
+        geohash_polygon.encode_many([-73.0], [45.0], 0)
+
+
+def test_encode_many_with_explicit_threads():
+    lngs = [-73.5540, -79.3832]
+    lats = [45.5088, 43.6532]
+    result_single = geohash_polygon.encode_many(lngs, lats, 7, num_threads=1)
+    result_multi = geohash_polygon.encode_many(lngs, lats, 7, num_threads=2)
+    assert result_single == result_multi
+
+
+# ── decode_many ───────────────────────────────────────────────────────────────
+
+def test_decode_many_invalid_raises():
+    with pytest.raises(Exception):
+        geohash_polygon.decode_many(["not_a_geohash!"])
+
+
+def test_decode_many_matches_decode_exactly():
+    hashes = [
+        geohash_polygon.encode(lng, lat, 7)
+        for lng, lat in [(-73.5540, 45.5088), (-79.3832, 43.6532)]
+    ]
+    pairs = geohash_polygon.decode_many(hashes)
+    assert len(pairs) == len(hashes)
+    for (lat, lng), h in zip(pairs, hashes):
+        expected_lat, expected_lng, _, _ = geohash_polygon.decode_exactly(h)
+        assert abs(lat - expected_lat) < 1e-10
+        assert abs(lng - expected_lng) < 1e-10
+
+
+# ── decode_many_exactly ───────────────────────────────────────────────────────
+
+def test_decode_many_exactly_invalid_raises():
+    with pytest.raises(Exception):
+        geohash_polygon.decode_many_exactly(["not_a_geohash!"])
+
+
+def test_decode_many_exactly_matches_decode_exactly():
+    hashes = [
+        geohash_polygon.encode(lng, lat, 7)
+        for lng, lat in [(-73.5540, 45.5088), (-79.3832, 43.6532)]
+    ]
+    results = geohash_polygon.decode_many_exactly(hashes)
+    assert len(results) == len(hashes)
+    for (lat, lng, lat_err, lng_err), h in zip(results, hashes):
+        e_lat, e_lng, e_lat_err, e_lng_err = geohash_polygon.decode_exactly(h)
+        assert abs(lat - e_lat) < 1e-10
+        assert abs(lng - e_lng) < 1e-10
+        assert abs(lat_err - e_lat_err) < 1e-10
+        assert abs(lng_err - e_lng_err) < 1e-10
+
+
+def test_decode_many_exactly_with_explicit_threads():
+    hashes = [geohash_polygon.encode(-73.5540, 45.5088, 7)]
+    r1 = geohash_polygon.decode_many_exactly(hashes, num_threads=1)
+    r2 = geohash_polygon.decode_many_exactly(hashes, num_threads=2)
+    assert r1 == r2
+
+
+# ── expand_geohashes (single group) ──────────────────────────────────────────
+
+def test_expand_geohashes_negative_m_raises():
+    center = geohash_polygon.encode(-73.5540, 45.5088, 7)
+    with pytest.raises(ValueError, match="non-negative"):
+        geohash_polygon.expand_geohashes([center], -1.0)
+
+
+def test_expand_geohashes_nan_m_raises():
+    center = geohash_polygon.encode(-73.5540, 45.5088, 7)
+    with pytest.raises(ValueError):
+        geohash_polygon.expand_geohashes([center], float("nan"))
+
+
+def test_expand_geohashes_inf_m_raises():
+    center = geohash_polygon.encode(-73.5540, 45.5088, 7)
+    with pytest.raises(ValueError):
+        geohash_polygon.expand_geohashes([center], float("inf"))
+
+
+def test_expand_geohashes_invalid_hash_raises():
+    with pytest.raises(Exception):
+        geohash_polygon.expand_geohashes(["not_a_geohash!"], 0.10)
+
+
+def test_expand_mapping_invalid_hash_raises():
+    with pytest.raises(Exception):
+        geohash_polygon.expand_geohash_mapping([["not_a_geohash!"]], 0.10)
+
+
+def test_expand_geohashes_mixed_precision_raises():
+    h5 = geohash_polygon.encode(-73.5540, 45.5088, 5)
+    h7 = geohash_polygon.encode(-73.5540, 45.5088, 7)
+    with pytest.raises(ValueError, match="same precision"):
+        geohash_polygon.expand_geohashes([h5, h7], 100.0)
+
+
+def test_expand_mapping_mixed_precision_raises():
+    h5 = geohash_polygon.encode(-73.5540, 45.5088, 5)
+    h7 = geohash_polygon.encode(-73.5540, 45.5088, 7)
+    with pytest.raises(ValueError, match="same precision"):
+        geohash_polygon.expand_geohash_mapping([[h5, h7]], 100.0)
+
+
+def test_expand_geohashes_empty():
+    assert geohash_polygon.expand_geohashes([], 1.0) == []
+
+
+def test_expand_geohashes_zero_hops_returns_original():
+    center = geohash_polygon.encode(-73.5540, 45.5088, 7)
+    result = geohash_polygon.expand_geohashes([center], 0.0)
+    assert result == [center]
+
+
+def test_expand_geohashes_one_hop_gives_nine_cells():
+    # One geohash expanded by 1 hop: original + 8 neighbors = 9 cells.
+    # n_hops = ceil(100 / ~152) = 1
+    center = geohash_polygon.encode(-73.5540, 45.5088, 7)
+    result = geohash_polygon.expand_geohashes([center], 100.0)
+    assert len(result) == 9
+    assert center in result
+
+
+def test_expand_geohashes_preserves_input():
+    hashes = [geohash_polygon.encode(-73.5540 + i * 0.002, 45.5088, 7) for i in range(3)]
+    result = geohash_polygon.expand_geohashes(hashes, 100.0)
+    assert set(hashes).issubset(set(result))
+    assert len(result) > len(hashes)
+
+
+def test_expand_geohashes_count_grows_with_expansion_m():
+    center = geohash_polygon.encode(-73.5540, 45.5088, 7)
+    hashes_1hop = geohash_polygon.expand_geohashes([center], 100.0)
+    hashes_2hop = geohash_polygon.expand_geohashes([center], 300.0)
+    assert len(hashes_2hop) > len(hashes_1hop)
+
+
+def _expansion_max_dist(orig_lng, orig_lat, orig_lng_err, orig_lat_err, expansion_m):
+    """Upper bound on center-to-center distance for a BFS expansion.
+
+    BFS uses n_hops = ceil(expansion_m / min_full_dim). Worst case is always
+    stepping diagonally, so max distance = n_hops × full_cell_diagonal.
+    """
+    half_h = orig_lat_err * 111_000
+    half_w = orig_lng_err * 111_320 * math.cos(math.radians(orig_lat))
+    n_hops = math.ceil(expansion_m / (2 * min(half_h, half_w)))
+    # 1% buffer for flat-Earth vs haversine divergence
+    return n_hops * math.sqrt((2 * half_h) ** 2 + (2 * half_w) ** 2) * 1.01
+
+
+def test_expand_geohashes_added_cells_within_distance():
+    # Every added cell center must be within the BFS max-distance bound.
+    expansion_m = 300.0
+    center = geohash_polygon.encode(-73.5540, 45.5088, 7)
+    orig_lng, orig_lat = geohash_polygon.decode_many([center])[0]
+    _, _, orig_lng_err, orig_lat_err = geohash_polygon.decode_exactly(center)
+    max_dist = _expansion_max_dist(orig_lng, orig_lat, orig_lng_err, orig_lat_err, expansion_m)
+    expanded = set(geohash_polygon.expand_geohashes([center], expansion_m))
+    for h in expanded - {center}:
+        lng, lat = geohash_polygon.decode_many([h])[0]
+        dist = haversine_m(orig_lng, orig_lat, lng, lat)
+        assert dist <= max_dist, f"{h} center is {dist:.1f}m from origin, max allowed {max_dist:.1f}m"
+
+
+def test_expand_geohashes_ew_coverage_at_high_latitude():
+    # At ~60°N (Whitehorse), cell width ≈ half cell height. Without the lat-adjusted
+    # hop count, east/west expansion uses too few hops. Verify all added cells stay
+    # within the BFS max-distance bound (which would be violated pre-fix for diagonal cells).
+    expansion_m = 500.0
+    center = geohash_polygon.encode(-135.0, 60.7, 7)  # Whitehorse area
+    orig_lng, orig_lat = geohash_polygon.decode_many([center])[0]
+    _, _, orig_lng_err, orig_lat_err = geohash_polygon.decode_exactly(center)
+    max_dist = _expansion_max_dist(orig_lng, orig_lat, orig_lng_err, orig_lat_err, expansion_m)
+    expanded = set(geohash_polygon.expand_geohashes([center], expansion_m))
+    for h in expanded - {center}:
+        lng, lat = geohash_polygon.decode_many([h])[0]
+        dist = haversine_m(orig_lng, orig_lat, lng, lat)
+        assert dist <= max_dist, f"{h} center is {dist:.1f}m from origin, max allowed {max_dist:.1f}m"
+
+
+# ── expand_geohash_mapping (multiple groups) ──────────────────────────────────
+
+def test_expand_mapping_empty_input():
+    assert geohash_polygon.expand_geohash_mapping([], 1.0) == []
+
+
+def test_expand_mapping_zero_hops_returns_original():
+    center = geohash_polygon.encode(-73.5540, 45.5088, 7)
+    result = geohash_polygon.expand_geohash_mapping([[center]], 0.0)
+    assert len(result) == 1
+    assert result[0] == [center]
+
+
+def test_expand_mapping_single_cell_one_hop_gives_nine_cells():
+    center = geohash_polygon.encode(-73.5540, 45.5088, 7)
+    result = geohash_polygon.expand_geohash_mapping([[center]], 100.0)
+    assert len(result) == 1
+    assert len(result[0]) == 9
+    assert center in result[0]
+
+
+def test_expand_mapping_order_preserved():
+    # Output[i] must correspond to input[i], not some arbitrary reordering.
+    coords = [(-73.5540, 45.5088), (-87.6298, 41.8781), (-79.3832, 43.6532)]
+    groups = [[geohash_polygon.encode(lng, lat, 7)] for lng, lat in coords]
+    result = geohash_polygon.expand_geohash_mapping(groups, 100.0)
+    assert len(result) == 3
+    for i, (lng, lat) in enumerate(coords):
+        expected_center = geohash_polygon.encode(lng, lat, 7)
+        assert expected_center in result[i]
+
+
+def test_expand_mapping_mixed_precisions():
+    # Groups at different precision levels each use their own cell size for n_hops.
+    # p5 cells are ~4900 m; p7 cells are ~152 m.
+    # With a 1000 m expansion:
+    #   p5: ceil(1000 / 4900) = 1 hop  → 9 cells
+    #   p7: ceil(1000 / 152)  = 7 hops → many more cells
+    # If a global sample from p5 were used, p7 would wrongly get 1 hop too.
+    h5 = geohash_polygon.encode(-73.5540, 45.5088, 5)
+    h7 = geohash_polygon.encode(-87.6298, 41.8781, 7)
+    result = geohash_polygon.expand_geohash_mapping([[h5], [h7]], 1000.0)
+    assert len(result[0]) == 9      # p5: 1 hop
+    assert len(result[1]) > 9       # p7: many more hops
+
+
+def test_expand_mapping_two_groups_are_independent():
+    # Two groups far apart should expand independently with no crosstalk.
+    h1 = geohash_polygon.encode(-73.5540, 45.5088, 7)  # Montreal
+    h2 = geohash_polygon.encode(-87.6298, 41.8781, 7)  # Chicago
+    result = geohash_polygon.expand_geohash_mapping([[h1], [h2]], 100.0)
+    assert len(result[0]) == 9
+    assert len(result[1]) == 9
+    assert set(result[0]).isdisjoint(set(result[1]))


### PR DESCRIPTION
## Centralise geohash ops + add geography expansion

 ### What

  - encode / decode family — ports encode, encode_many, decode, decode_exactly, decode_many, decode_many_exactly from pygeohash-fast (unmaintained). API-compatible; decode/decode_many return
  (lng, lat, …) matching pygeohash-fast, decode_exactly/decode_many_exactly return (lat, lng, lat_err, lng_err) matching pygeohash.
  - expand_geohash_mapping — takes a dict[geography_id, list[geohash]], expands each geography outward by expansion_km km via BFS frontier expansion, returns flat (geog_ids, geohashes) lists ready
   for PyArrow/DuckDB. Hop count is derived from the cell size of a sample hash so it works at any precision. Parallelised across geographies with Rayon.
  - rayon added as a dependency; version bumped 0.4.1 → 0.5.0.
  - Full test coverage in tests/test_geohash_ops.py.