### PR TITLE
fix: add py.typed marker for PEP 561 compliance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,7 +733,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-polygon-geohasher"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "criterion",
  "geo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-polygon-geohasher"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 authors = ["Francois Maillet <francois@locallogic.co>"]
 homepage = "https://github.com/nexmoov/rusty-polygon-geohasher"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rusty-polygon-geohasher"
-version = "0.6.1"
+version = "0.6.2"
 description = "A Rust implementation of the polygon to geohash library"
 readme = "README.md"
 authors = ["Francois Maillet <francois@locallogic.co>"]
@@ -44,5 +44,6 @@ python = "^3.11"
 [tool.maturin]
 features = ["pyo3/extension-module"]
 include = [
-  { path = "geohash_polygon/__init__.pyi", format = "wheel" },
+  "geohash_polygon/py.typed",
+  "geohash_polygon/__init__.pyi",
 ]


### PR DESCRIPTION
fix: add py.typed marker for PEP 561 compliance

chore: bump version to 0.6.2